### PR TITLE
Added a repository field to package.json to remove a warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "watch": "webpack --watch",
     "dev": "webpack-dev-server --port 3000"
   },
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/abingham/accu-2017-elm-app"
+  },
   "author": "Sixty North AS",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
The `npm install` command gave an warning:

    npm WARN accu-2017-elm-app@1.0.0 No repository field.

This pull-request fixes that.
